### PR TITLE
chore(airflow): add initial tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,6 @@ env:
   _AIRFLOW_WWW_USER_LAST_NAME: Admin
   _AIRFLOW_WWW_USER_PASSWORD: airflow
   _AIRFLOW_WWW_USER_USERNAME: airflow
-  POSTGRES_CREDENTIALS_FILE_DIR_HOST: $HOME/.config
   ENV: dev
   FLOWER_PORT: 28888
   FLOWER_PASSWORD: flowerpass
@@ -97,8 +96,10 @@ jobs:
         docker ps
         make docker-wait-all
 
-
-# change for tests of airflow
+    - name: Test DAGs with Pytest
+      run: |
+        pip install pytest
+        pytest docker/airflow
 
     - name: test cron scripts
       run: |

--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -1,0 +1,6 @@
+name: epigraphhub
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - pytest

--- a/docker/airflow/dags/foph_dag.py
+++ b/docker/airflow/dags/foph_dag.py
@@ -1,6 +1,6 @@
 """
 @author Luã Bida Vacaro | github.com/luabida
-@date Last change on 2022-09-23
+@date Last change on 2022-09-26
 
 This is an Airflow DAG. This DAG is responsible for running scripts for
 collecting data from Federal Office of Public Health (FOPH). The API 
@@ -294,6 +294,8 @@ def foph():
         another one if followed by a right bit shift (>>). A Branch
         task will be branched if more than one task is defined as its
         dependency and merged using a common empty task. 
+        All tasks inside this loop will become a individually task with
+        its own workflow, based on the `tablename`.
         """
         start >> down >> comp
         comp >> same_shape >> done >> end

--- a/docker/airflow/dags/foph_dag.py
+++ b/docker/airflow/dags/foph_dag.py
@@ -106,9 +106,9 @@ def foph():
     api and update the Postgres Database every week.
     As this DAG contains a for loop, every iteration will represent different
     tasks instances. The loop goes through the content found by the method
-    `get_csv_relation()` and it is stored in `tables` as a dictionary of URLs 
+    `get_csv_relation()` and it is stored in `tables` as a dictionary of URLs
     and table names, each entry will then have their own tasks as defined inside
-    the for loop. 
+    the for loop.
 
     Arguments
     ---------
@@ -116,47 +116,47 @@ def foph():
 
     owner (str)             : The DAG's owner. Only the owner or admin can
                               view or run this DAG.
-    depends_on_past (bool)  : If set to True, a task fail will stop 
-                              further tasks and future DAGs to run until 
+    depends_on_past (bool)  : If set to True, a task fail will stop
+                              further tasks and future DAGs to run until
                               be fixed or manually ran.
     start_date (pendulum)   : When the DAG is ran for the first time.
     email (str)             : Email for failing reports.
     email_on_failure (bool) : If a task fails, an email will be sent.
     email_on_retry (bool)   : An email will be sent every retry attempt.
-    retries (int)           : How many times a task should retry if it 
+    retries (int)           : How many times a task should retry if it
                               fails.
     retry_delay (timedelta) : The delay between each retry.
     schedule_interval (str) : The interval between each DAG run. DAG uses
-                              CRON syntax too ("* * * * *"). 
-    default_args (dict)     : The same arguments can be passed to 
+                              CRON syntax too ("* * * * *").
+    default_args (dict)     : The same arguments can be passed to
                               different DAGs using default_args.
-    catchup (bool)          : If set to True, the DAG will look for past 
-                              dates to backfill the data if data 
+    catchup (bool)          : If set to True, the DAG will look for past
+                              dates to backfill the data if data
                               collection is configured correctly.
                               @warning Not available for FOPH DAG.
 
     Methods
     -------
 
-    get_csv_relation()      : This method will retrieve the CSV relation for 
+    get_csv_relation()      : This method will retrieve the CSV relation for
                               each file to be downloaded and stores as an dict
 
-    download(url)           : Method responsible for executing the script from 
-                              epigraphhub_py API to download the CSV file from 
-                              each URL in dict `tables` 
-    
-    compare(tablename, url) : Used for comparing dates from SQL Database with 
+    download(url)           : Method responsible for executing the script from
+                              epigraphhub_py API to download the CSV file from
+                              each URL in dict `tables`
+
+    compare(tablename, url) : Used for comparing dates from SQL Database with
                               the downloaded CSV file, evaluates the max date
-                              found on both and returns the string that 
+                              found on both and returns the string that
                               corresponds the next task to be run.
-    
-    load_to_db(table, url)  : Used in `load_into_db` task to run epigraphhub_py 
-                              Python Script to connect and update the rows of 
-                              each table on `tables` into its respective SQL 
+
+    load_to_db(table, url)  : Used in `load_into_db` task to run epigraphhub_py
+                              Python Script to connect and update the rows of
+                              each table on `tables` into its respective SQL
                               table.
-    
-    parse_table(table)      : Create location, iso_code and date indices if  
-                              missing in the CSV file. 
+
+    parse_table(table)      : Create location, iso_code and date indices if
+                              missing in the CSV file.
     """
     start = EmptyOperator(
         task_id="start",
@@ -181,7 +181,7 @@ def foph():
 
     def compare(tablename, url):
         """
-        Used for comparing the maximum date found on the CSV file and in 
+        Used for comparing the maximum date found on the CSV file and in
         the SQL table, respectively. Evaluate the datetimes and returns
         the string that corresponds to the next task to be run.
 
@@ -216,7 +216,7 @@ def foph():
 
         Args:
             tablename (str) : Name of the table to be updated
-            url (str)       : URL of the CSV as specified in `tables` dict        
+            url (str)       : URL of the CSV as specified in `tables` dict
         """
         filename = str(url).split("/")[-1]
         load_into_db.load(table, filename)
@@ -306,4 +306,3 @@ def foph():
 
 
 dag = foph()
-

--- a/docker/airflow/dags/owid_dag.py
+++ b/docker/airflow/dags/owid_dag.py
@@ -100,42 +100,42 @@ def owid():
 
     owner (str)             : The DAG's owner. Only the owner or admin can
                               view or run this DAG.
-    depends_on_past (bool)  : If set to True, a task fail will stop 
-                              further tasks and future DAGs to run until 
+    depends_on_past (bool)  : If set to True, a task fail will stop
+                              further tasks and future DAGs to run until
                               be fixed or manually ran.
     start_date (pendulum)   : When the DAG is ran for the first time.
     email (str)             : Email for failing reports.
     email_on_failure (bool) : If a task fails, an email will be sent.
     email_on_retry (bool)   : An email will be sent every retry attempt.
-    retries (int)           : How many times a task should retry if it 
+    retries (int)           : How many times a task should retry if it
                               fails.
     retry_delay (timedelta) : The delay between each retry.
     schedule_interval (str) : The interval between each DAG run. DAG uses
-                              CRON syntax too ("* * * * *"). 
-    default_args (dict)     : The same arguments can be passed to 
+                              CRON syntax too ("* * * * *").
+    default_args (dict)     : The same arguments can be passed to
                               different DAGs using default_args.
-    catchup (bool)          : If set to True, the DAG will look for past 
-                              dates to backfill the data if data 
+    catchup (bool)          : If set to True, the DAG will look for past
+                              dates to backfill the data if data
                               collection is configured correctly.
                               @warning Not available for OWID.
 
     Methods
     -------
 
-    download_owid()  : Method responsible for executing the script from 
-                       epigraphhub_py API to download the CSV file from OWID 
+    download_owid()  : Method responsible for executing the script from
+                       epigraphhub_py API to download the CSV file from OWID
                        dataset and stores it in the OWID's temporary directory
-    
+
     comp_data()      : Used for comparing the SQL Database with the downloaded
-                       CSV file, evaluates the shapes from both and returns 
+                       CSV file, evaluates the shapes from both and returns
                        the string that corresponds the next task to be run.
-    
-    insert_into_db() : Used in `load_into_db` task to run epigraphhub_py 
-                       Python Script to connect and update the rows of 
+
+    insert_into_db() : Used in `load_into_db` task to run epigraphhub_py
+                       Python Script to connect and update the rows of
                        `owid_covid` SQL table.
-    
+
     parse_index()    : Create location, iso_code and date indexes if they are
-                       missing in the CSV file. 
+                       missing in the CSV file.
     """
     start = EmptyOperator(
         task_id="start",
@@ -153,7 +153,7 @@ def owid():
                                    corresponding with the task for update SQL
                                    table.
             same_shape (str)     : If evaluation is True, returns the string
-                                   corresponding to the task that ends the 
+                                   corresponding to the task that ends the
                                    workflow. No update is needed.
         """
         db_shape = compare_data.database_size(remote=False)
@@ -162,7 +162,7 @@ def owid():
         if not db_shape or not csv_shape:
             raise Exception("CSV file or Table not found.")
         same_shape = eval("db_shape == csv_shape")
-        
+
         if not same_shape:
             logger.info(f"Table owid_covid needs update.")
             logger.info(f"Proceeding to update table owid_covid.")

--- a/docker/airflow/dags/tests/dagbag_test.py
+++ b/docker/airflow/dags/tests/dagbag_test.py
@@ -3,22 +3,22 @@ import pytest
 from airflow.models import DagBag
 
 
-
 def test_no_import_errors():
     dag_bag = DagBag(include_examples=False)
     assert len(dag_bag.import_errors) == 0, "No import failures."
 
+
 def test_each_dag_existence_in_default_airflow_location():
     dags = [
         # Production:
-        'owid',
-        'foph',
-        'colombia',
+        "owid",
+        "foph",
+        "colombia",
         # Development:
-        'web_status_test',
-        ]
-    airflow_path = os.getenv('AIRFLOW_HOME')
-    dag_bag = DagBag(include_examples=False, dag_folder=f'{airflow_path}/dags')
+        "web_status_test",
+    ]
+    airflow_path = os.getenv("AIRFLOW_HOME")
+    dag_bag = DagBag(include_examples=False, dag_folder=f"{airflow_path}/dags")
     print(dag_bag.dag_ids)
     for dag in dags:
         assert dag in dag_bag.dag_ids, f"{dag} DAG found."

--- a/docker/airflow/dags/tests/owid_dag_test.py
+++ b/docker/airflow/dags/tests/owid_dag_test.py
@@ -1,6 +1,7 @@
 import pytest
 from airflow.models import DagBag
 
+
 def test_no_import_errors():
-  dag_bag = DagBag(include_examples=False)
-  assert len(dag_bag.import_errors) == 0, "No Import Failures"
+    dag_bag = DagBag(include_examples=False)
+    assert len(dag_bag.import_errors) == 0, "No Import Failures"

--- a/docker/airflow/dags/tests/owid_dag_test.py
+++ b/docker/airflow/dags/tests/owid_dag_test.py
@@ -1,0 +1,6 @@
+import pytest
+from airflow.models import DagBag
+
+def test_no_import_errors():
+  dag_bag = DagBag(include_examples=False)
+  assert len(dag_bag.import_errors) == 0, "No Import Failures"

--- a/docker/airflow/dags/tests/owid_dag_test.py
+++ b/docker/airflow/dags/tests/owid_dag_test.py
@@ -1,7 +1,24 @@
+import os
 import pytest
 from airflow.models import DagBag
 
 
+
 def test_no_import_errors():
     dag_bag = DagBag(include_examples=False)
-    assert len(dag_bag.import_errors) == 0, "No Import Failures"
+    assert len(dag_bag.import_errors) == 0, "No import failures."
+
+def test_each_dag_existence_in_default_airflow_location():
+    dags = [
+        # Production:
+        'owid',
+        'foph',
+        'colombia',
+        # Development:
+        'web_status_test',
+        ]
+    airflow_path = os.getenv('AIRFLOW_HOME')
+    dag_bag = DagBag(include_examples=False, dag_folder=f'{airflow_path}/dags')
+    print(dag_bag.dag_ids)
+    for dag in dags:
+        assert dag in dag_bag.dag_ids, f"{dag} DAG found."

--- a/docker/airflow/dags/tests/test_tables_existence.py
+++ b/docker/airflow/dags/tests/test_tables_existence.py
@@ -1,0 +1,114 @@
+from sqlalchemy import text
+import logging as logger
+import pytest
+
+from epigraphhub.connection import get_engine
+from epigraphhub.settings import env
+
+
+public_tables = [
+    "owid_covid",
+    # 'iso_alpha3_country_codes',
+]
+
+colombia_tables = [
+    "positive_cases_covid_d",
+    # 'casos_positivos_covid',
+]
+
+switzerland_tables = [
+    # 'foph_cases',
+    # 'foph_casesvaccpersons',
+    # 'foph_covidcertificates',
+    # 'foph_death',
+    # 'foph_deathvaccpersons',
+    # 'foph_hosp',
+    # 'foph_hospcapacity',
+    # 'foph_hospvaccpersons',
+    # 'foph_intcases',
+    # 'foph_re',
+    # 'foph_test',
+    # 'foph_testpcrantigen',
+    # 'foph_virusvariantswgs',
+    "foph_casesvaccpersons_d",
+    "foph_cases_d",
+    "foph_hosp_d",
+    "foph_hospvaccpersons_d",
+    "foph_death_d",
+    "foph_deathvaccpersons_d",
+    "foph_test_d",
+    "foph_testpcrantigen_d",
+    "foph_hospcapacity_d",
+    "foph_hospcapacitycertstatus_d",
+    "foph_re_d",
+    "foph_intcases_d",
+    "foph_virusvariantswgs_d",
+    "foph_covidcertificates_d",
+    # df_val_hosp_cantons
+    # janne_scenario_1
+    # janne_scenario_2
+    # janne_scenario_3
+    # janne_scenario_4
+    # ml_for_icu_all_cantons
+    # ml_for_hosp_all_cantons
+    # ml_forecast_hosp_up
+    # ml_for_total_all_cantons
+    # ml_forecast
+    # ml_forecast_hosp
+    # ml_forecast_icu_up
+    # ml_forecast_icu
+    # ml_forecast_total
+    # ml_val_hosp_all_cantons
+    # ml_val_icu_all_cantons
+    # ml_val_total_all_cantons
+    # ml_validation
+    # ml_validation_hosp_up
+    # ml_validation_icu
+    # ml_validation_icu_up
+    # ml_validation_total
+    # phosp_post
+    # prev_post
+    # existance
+]
+
+
+def _return_true_if_table_exists(schema, table) -> bool:
+    engine = get_engine(credential_name=env.db.default_credential)
+    try:
+        with engine.connect().execution_options(autocommit=True) as conn:
+            result = conn.execute(
+                text(
+                    f"""
+                    SELECT EXISTS (
+                        SELECT FROM 
+                            pg_tables
+                        WHERE 
+                            schemaname = '{schema}' AND 
+                            tablename  = '{table}'
+                        );
+            """
+                )
+            )
+            for row in result:
+                return row["exists"]
+
+    except Exception as e:
+        logger.error(f"Could not access {table} table\n{e}")
+        raise (e)
+
+
+def _check_schema_integrity(schema, tables_list):
+    for table in tables_list:
+        return _return_true_if_table_exists(schema, table)
+
+
+def test_tables_in_public_schema():
+    assert _check_schema_integrity(schema="public", tables_list=public_tables)
+
+
+def test_tables_in_colombia_schema():
+    assert _check_schema_integrity(schema="colombia", tables_list=colombia_tables)
+
+
+def test_tables_in_switzerland_schema():
+    assert _check_schema_integrity(schema="switzerland", tables_list=switzerland_tables)

--- a/docker/airflow/dags/tests/webservices.txt
+++ b/docker/airflow/dags/tests/webservices.txt
@@ -1,3 +1,9 @@
+-------------------------------------------------
+The list below contains all websites to be tested
+by web_status_test DAG, where their requests will 
+be checked for status code OK (^200) every day.
+-------------------------------------------------
+
 https://epigraphhub.org
 https://www.epigraphhub.org
 https://dash.epigraphhub.org

--- a/docker/airflow/dags/tests/webservices.txt
+++ b/docker/airflow/dags/tests/webservices.txt
@@ -1,0 +1,5 @@
+https://epigraphhub.org
+https://www.epigraphhub.org
+https://dash.epigraphhub.org
+https://epigraphhub.org/covidch
+https://airflow.epigraphhub.org

--- a/docker/airflow/dags/tests/webservices_status_dag.py
+++ b/docker/airflow/dags/tests/webservices_status_dag.py
@@ -8,10 +8,10 @@ from airflow.decorators import dag, task
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 
-AIRFLOW_HOME = os.getenv('AIRFLOW_HOME')
+AIRFLOW_HOME = os.getenv("AIRFLOW_HOME")
 
 default_args = {
-    "owner": "Airflow", # This should be visible for the Admin only
+    "owner": "Airflow",  # This should be visible for the Admin only
     "depends_on_past": False,
     "start_date": pendulum.datetime(2022, 9, 26),
     "email": ["admin@epgraphhub.org"],
@@ -31,14 +31,14 @@ def web_status_test():
     """
     This DAG will send a request to every URL in `webservices.txt`, where
     each URL has its own task that will be marked as success if the URL
-    request responds any 200 code. 
+    request responds any 200 code.
     """
 
-    exp = '^http[s]?:\/\/' # Enable comments in .txt file
+    exp = "^http[s]?:\/\/"  # Enable comments in .txt file
     services = []
-    with open(f'{AIRFLOW_HOME}/dags/tests/webservices.txt', 'r') as f:
+    with open(f"{AIRFLOW_HOME}/dags/tests/webservices.txt", "r") as f:
         file = f.read()
-        matches = re.findall(f'{exp}.*', file, re.MULTILINE)
+        matches = re.findall(f"{exp}.*", file, re.MULTILINE)
         for match in matches:
             services.append(match)
 
@@ -46,10 +46,10 @@ def web_status_test():
         # Return True if the status code is 2**
         resp = urlopen(url)
         code_str = str(resp.code)
-        if code_str.startswith('2'):
-            logging.info(f'{url} is active.')
+        if code_str.startswith("2"):
+            logging.info(f"{url} is active.")
         else:
-            raise Exception(f'Could no reach {url}')
+            raise Exception(f"Could no reach {url}")
 
     start = EmptyOperator(
         task_id="test_EGH_URLs_status",
@@ -58,19 +58,19 @@ def web_status_test():
     end = EmptyOperator(
         task_id="tests_passed",
         trigger_rule="all_success",
-    )    
-    
+    )
 
     for service_url in services:
-        service = re.sub(exp, '', service_url)
-        service = service.replace('/','-')
-        
+        service = re.sub(exp, "", service_url)
+        service = service.replace("/", "-")
+
         check_url_status = PythonOperator(
-            task_id = service,
+            task_id=service,
             python_callable=url_status_check,
             op_kwargs={"url": service_url},
-        )                
+        )
 
         start >> check_url_status >> end
+
 
 dag = web_status_test()

--- a/docker/airflow/dags/tests/webservices_status_dag.py
+++ b/docker/airflow/dags/tests/webservices_status_dag.py
@@ -1,0 +1,76 @@
+import logging
+import re
+import pendulum
+import os
+from datetime import timedelta
+from urllib.request import urlopen
+from airflow.decorators import dag, task
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator
+
+AIRFLOW_HOME = os.getenv('AIRFLOW_HOME')
+
+default_args = {
+    "owner": "Airflow", # This should be visible for the Admin only
+    "depends_on_past": False,
+    "start_date": pendulum.datetime(2022, 9, 26),
+    "email": ["admin@epgraphhub.org"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 3,
+    "retry_delay": timedelta(minutes=5),
+}
+
+
+@dag(
+    schedule_interval="@daily",
+    default_args=default_args,
+    catchup=False,
+)
+def web_status_test():
+    """
+    This DAG will send a request to every URL in `webservices.txt`, where
+    each URL has its own task that will be marked as success if the URL
+    request responds any 200 code. 
+    """
+
+    exp = '^http[s]?:\/\/' # Enable comments in .txt file
+    services = []
+    with open(f'{AIRFLOW_HOME}/dags/tests/webservices.txt', 'r') as f:
+        file = f.read()
+        matches = re.findall(f'{exp}.*', file, re.MULTILINE)
+        for match in matches:
+            services.append(match)
+
+    def url_status_check(url):
+        # Return True if the status code is 2**
+        resp = urlopen(url)
+        code_str = str(resp.code)
+        if code_str.startswith('2'):
+            logging.info(f'{url} is active.')
+        else:
+            raise Exception(f'Could no reach {url}')
+
+    start = EmptyOperator(
+        task_id="test_EGH_URLs_status",
+    )
+
+    end = EmptyOperator(
+        task_id="tests_passed",
+        trigger_rule="all_success",
+    )    
+    
+
+    for service_url in services:
+        service = re.sub(exp, '', service_url)
+        service = service.replace('/','-')
+        
+        check_url_status = PythonOperator(
+            task_id = service,
+            python_callable=url_status_check,
+            op_kwargs={"url": service_url},
+        )                
+
+        start >> check_url_status >> end
+
+dag = web_status_test()


### PR DESCRIPTION
This PR aims to implement initial base tests with Airflow. Some tests will be done using Airflow's Engine to be run within an interval, others will aim the methods Airflow is using in its Tasks and need to be run on CI.

All tests that are in Airflow's context will reside inside default DAG's directory and if the test consists in a DAG itself, their visibility and usage have to be controlled using a Admin in the owner argument.